### PR TITLE
accept now returns a file descriptor to allow it to work with multi-threaded servers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
-	rustc socket.rc -g
+	rustc socket.rc
 
 test:
-	rustc --test socket.rc -g
+	rustc --test socket.rc
 	export RUST_LOG=socket=3 && $(DEBUGGER) ./socket
 
 clean:

--- a/socket.rs
+++ b/socket.rs
@@ -272,7 +272,7 @@ fn send(sock: @socket_handle, buf: [u8]) -> result<uint, str> unsafe {
 }
 
 fn recv(sock: @socket_handle, len: uint) -> result<([u8], uint), str> unsafe {
-    let buf = vec::from_elem(len, 0u8);
+    let buf = vec::from_elem(len + 1u, 0u8);
     let bytes = c::recv(**sock, vec::unsafe::to_ptr(buf), len as libc::c_int, 0i32);
     if bytes == -1_i32 {
         log_err(#fmt["recv error"]);

--- a/socket.rs
+++ b/socket.rs
@@ -386,7 +386,7 @@ fn test_server_client() {
             // client
             task::spawn {||
                 result::chain(connect("localhost", port as u16)) {|s|
-                    let res = send(s, str::bytes(test_str));
+                    let res = str::as_buf(test_str, {|buf| send_buf(s, buf, str::len(test_str))});
                     assert result::is_success(res);
                     result::ok(s)
                 };

--- a/socket.rs
+++ b/socket.rs
@@ -186,7 +186,7 @@ fn getaddrinfo(host: str, port: u16, f: fn(addrinfo) -> bool) -> option<str> uns
             }
         }
     }
-    c::freeaddrinfo(servinfo);
+    c::freeaddrinfo(servinfo); 
     result
 }
 
@@ -240,7 +240,7 @@ fn bind_socket(host: str, port: u16) -> result<@socket_handle, str> unsafe {
     };
     alt err
     {
-    	    option::some(mesg) {result::err(mesg)}
+    	    option::some(mesg) {result::err(copy(mesg))}
          option::none           {result::err("bind failed to find an address")}
     }
 }
@@ -263,7 +263,7 @@ fn connect(host: str, port: u16) -> result<@socket_handle, str> {
     };
     alt err
     {
-    	    option::some(mesg) {result::err(mesg)}
+    	    option::some(mesg) {result::err(copy(mesg))}
          option::none           {result::err("connect failed to find an address")}
     }
 }
@@ -301,7 +301,7 @@ fn accept(sock: @socket_handle) -> result<(libc::c_int, str), str> unsafe {
     }
 }
 
-fn send(sock: @socket_handle, buf: [u8]) -> result<uint, str> unsafe {
+fn send(sock: @socket_handle, buf: [u8]/~) -> result<uint, str> unsafe {
     let amt = c::send(sock.sockfd, vec::unsafe::to_ptr(buf),
                       vec::len(buf) as libc::c_int, 0i32);
     if amt == -1_i32 {
@@ -323,7 +323,7 @@ fn send_buf(sock: @socket_handle, buf: *u8, len: uint) -> result<uint, str> unsa
     }
 }
 
-fn recv(sock: @socket_handle, len: uint) -> result<([u8], uint), str> unsafe {
+fn recv(sock: @socket_handle, len: uint) -> result<([u8]/~, uint), str> unsafe {
     let buf = vec::from_elem(len + 1u, 0u8);
     let bytes = c::recv(sock.sockfd, vec::unsafe::to_ptr(buf), len as libc::c_int, 0i32);
     if bytes == -1_i32 {
@@ -334,7 +334,7 @@ fn recv(sock: @socket_handle, len: uint) -> result<([u8], uint), str> unsafe {
     }
 }
 
-fn sendto(sock: @socket_handle, buf: [u8], to: sockaddr)
+fn sendto(sock: @socket_handle, buf: [u8]/~, to: sockaddr)
     -> result<uint, str> unsafe {
     let (to_saddr, to_len) = alt to {
       ipv4(s) { (unsafe::reinterpret_cast::<sockaddr4_in, sockaddr_storage>(s),
@@ -355,7 +355,7 @@ fn sendto(sock: @socket_handle, buf: [u8], to: sockaddr)
 }
 
 fn recvfrom(sock: @socket_handle, len: uint)
-    -> result<([u8], uint, sockaddr), str> unsafe {
+    -> result<([u8]/~, uint, sockaddr), str> unsafe {
     let from_saddr = (0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8);
     let unused: socklen_t = 0i32;
     let buf = vec::from_elem(len + 1u, 0u8);

--- a/socket.rs
+++ b/socket.rs
@@ -430,7 +430,7 @@ fn test_server_client() {
             task::spawn {||
                 result::chain(connect("localhost", port as u16)) {|s|
                     let res = str::as_buf(test_str, {|buf| send_buf(s, buf, str::len(test_str))});
-                    assert result::is_success(res);
+                    assert result::is_ok(res);
                     result::ok(s)
                 };
             };
@@ -441,7 +441,7 @@ fn test_server_client() {
                 assert str::eq("127.0.0.1", from_addr) || str::eq("::1", from_addr);
                 let c = @socket_handle(fd);
                 let res = recv(c, 1024u);
-                assert result::is_success(res);
+                assert result::is_ok(res);
                 let (buffer, len) = result::get(res);
                 assert len == str::len(test_str);
                 assert vec::slice(buffer, 0u, len) == str::bytes(test_str);
@@ -449,7 +449,7 @@ fn test_server_client() {
             }
         }
     };
-    assert result::is_success(r);
+    assert result::is_ok(r);
 }
 
 #[test]

--- a/socket.rs
+++ b/socket.rs
@@ -314,10 +314,10 @@ fn sendto(sock: @socket_handle, buf: [u8], to: sockaddr)
 }
 
 fn recvfrom(sock: @socket_handle, len: uint)
-    -> result<([u8], sockaddr), str> unsafe {
+    -> result<([u8], uint, sockaddr), str> unsafe {
     let from_saddr = (0i16, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8);
     let unused: socklen_t = 0i32;
-    let buf = vec::from_elem(len, 0u8);
+    let buf = vec::from_elem(len + 1u, 0u8);
     let amt = c::recvfrom(**sock, vec::unsafe::to_ptr(buf), vec::len(buf) as libc::c_int, 0i32,
                           ptr::addr_of(from_saddr), ptr::addr_of(unused));
     if amt == -1_i32 {
@@ -325,7 +325,7 @@ fn recvfrom(sock: @socket_handle, len: uint)
         result::err("recvfrom failed")
     } else {
         let (family, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = from_saddr;
-        result::ok((buf,
+        result::ok((buf, amt as uint,
                    if family == AF_INET as i16 {
                        ipv4(unsafe::reinterpret_cast(from_saddr))
                    } else {

--- a/socket.rs
+++ b/socket.rs
@@ -4,7 +4,7 @@ import std::rand;
 export sockaddr, getaddrinfo, bind_socket, socket_handle, connect, listen, accept,
        send, recv, sendto, recvfrom, setsockopt, enablesockopt, disablesockopt,
        htons, htonl, ntohs, ntohl, sockaddr4_in, sockaddr6_in, sockaddr_basic,
-       sockaddr_storage, inet_ntop;
+       sockaddr_storage, inet_ntop, send_buf;
 export SOCK_STREAM, SOCK_DGRAM, SOCK_RAW, SO_DEBUG, SO_ACCEPTCONN, SO_REUSEADDR, 
        SO_KEEPALIVE, SO_DONTROUTE, SO_BROADCAST, SO_LINGER, SO_OOBINLINE, SO_SNDBUF, 
        SO_RCVBUF, SO_SNDLOWAT, SO_RCVLOWAT, SO_SNDTIMEO, SO_RCVTIMEO, SO_ERROR, SO_TYPE,
@@ -266,6 +266,17 @@ fn send(sock: @socket_handle, buf: [u8]) -> result<uint, str> unsafe {
     if amt == -1_i32 {
         log_err(#fmt["send error"]);
         result::err("send failed")
+    } else {
+        result::ok(amt as uint)
+    }
+}
+
+// Useful for sending str data (where you want to use as_buf instead of as_buffer).
+fn send_buf(sock: @socket_handle, buf: *u8, len: uint) -> result<uint, str> unsafe {
+    let amt = c::send(**sock, buf, len as libc::c_int, 0i32);
+    if amt == -1_i32 {
+        log_err(#fmt["send error"]);
+        result::err("send_buf failed")
     } else {
         result::ok(amt as uint)
     }

--- a/socket.rs
+++ b/socket.rs
@@ -195,6 +195,7 @@ fn log_err(mesg: str)
     str::as_c_str(mesg) {|buffer| libc::perror(buffer)};
 }
 
+// TODO: Isn't socket::socket_handle redundant?
 resource socket_handle(sockfd: libc::c_int) {
     c::close(sockfd);
 }


### PR DESCRIPTION
Old code returned a socket_handle and resources cannot be sent to tasks which made it impossible to use with threaded servers.
